### PR TITLE
configure: Fix --enable-static flag

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -1275,7 +1275,8 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
---enable-static enable static linkage
+  --enable-static enable static linkage
+
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -2818,11 +2819,15 @@ fi
 
 # Check whether --enable-static was given.
 if test "${enable_static+set}" = set; then :
-  enableval=$enable_static; ENABLE_STATIC="--static"
-else
-  ENABLE_STATIC=""
+  enableval=$enable_static;
 fi
 
+
+if test "x$enable_static" = "xyes"; then
+	ENABLE_STATIC="--static"
+else
+	ENABLE_STATIC=""
+fi
 
 
 

--- a/src/configure.in
+++ b/src/configure.in
@@ -14,10 +14,14 @@ AC_PROG_MAKE_SET
 AC_HEADER_STDC
 
 dnl check for static linking
-AC_ARG_ENABLE(static,
-	[--enable-static enable static linkage],
-	ENABLE_STATIC="--static",
-	ENABLE_STATIC="")
+AC_ARG_ENABLE([static],
+	AC_HELP_STRING([--enable-static] [enable static linkage]))
+
+if test "x$enable_static" = "xyes"; then
+	ENABLE_STATIC="--static"
+else
+	ENABLE_STATIC=""
+fi
 AC_SUBST(ENABLE_STATIC)
 
 dnl BOOST include lib


### PR DESCRIPTION
The configure script previously used AC_ARG_ENABLE incorrectly[1],
resulting in static linking being always enabled. Fix this.

[1] https://autotools.io/autoconf/arguments.html