### PR TITLE
UKB-VERSION-GEN: Use /bin/sh in place of bash

### DIFF
--- a/src/UKB-VERSION-GEN
+++ b/src/UKB-VERSION-GEN
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # taken from git's GIT-VERSION-FILE
 


### PR DESCRIPTION
bash isn't necessarily available on all systems. This breaks on NixOS in particular.